### PR TITLE
update versioning.yml

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,13 +1,13 @@
 name: Tag latest
 
 on:
-  release:
-    types: [published, edited]
+  push:
+    branches:
+      - main
 
 jobs:
   actions-tagger:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: Actions-R-Us/actions-tagger@latest
-        with:
-          publish_latest_tag: true
+      - name: Run latest-tag
+        uses: EndBug/latest-tag@latest


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Updated the trigger for `versioning.yml` workflow to activate on push events to the `main` branch instead of release events.
- Switched the operating system in the workflow from Windows to Ubuntu.
- Upgraded the action used to tag the latest version.

> 🎉 Ubuntu takes the stage, no more Windows cage,
> On push to main, our workflow now engage.
> Tagging versions with a new sage,
> In the book of our code, we turn a new page. 🚀
<!-- end of auto-generated comment: release notes by openai -->