### PR TITLE
adjust temperature

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ inputs:
   openai_model_temperature:
     required: false
     description: 'Temperature for GPT model'
-    default: '0.0'
+    default: '0.05'
   openai_retries:
     required: false
     description:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

## Release Notes

**Chore:**
- Updated the default value of `openai_model_temperature` from `'0.0'` to `'0.05'` in `action.yml`.

> 🎉 A tweak so small, yet profound,
> 
> In our AI's logic, a new sound.
> 
> From zero to point oh five we steer,
> 
> Enhancing the model, loud and clear! 🚀
<!-- end of auto-generated comment: release notes by openai -->